### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,27 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwind from '@tailwindcss/vite'
 
+const env =
+  (globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> }
+  }).process?.env ?? {}
+
+const repository = env.GITHUB_REPOSITORY ?? ''
+const repositoryOwner = env.GITHUB_REPOSITORY_OWNER ?? env.GITHUB_ACTOR ?? ''
+const repositoryName = repository.split('/')[1] ?? ''
+const normalizedRepoName = repositoryName.toLowerCase()
+const normalizedOwner = repositoryOwner.toLowerCase()
+const isUserOrOrgSite =
+  normalizedRepoName !== '' &&
+  normalizedOwner !== '' &&
+  normalizedRepoName === `${normalizedOwner}.github.io`
+const isGitHubPagesBuild =
+  env.GITHUB_ACTIONS === 'true' && repositoryName !== ''
+const basePath =
+  isGitHubPagesBuild && !isUserOrOrgSite ? `/${repositoryName}/` : '/'
+
 // https://vite.dev/config/
 export default defineConfig({
+  base: basePath,
   plugins: [react(), tailwind()],
 })


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the site and deploys it to GitHub Pages, including a configure step so deployments succeed when Pages isn't pre-enabled
- configure the Vite base path so repository deployments work correctly on Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92f0d2b28832c825f18ceeca0e64f